### PR TITLE
Add support for swift types to Attribute

### DIFF
--- a/QueryKit/Attribute.swift
+++ b/QueryKit/Attribute.swift
@@ -30,26 +30,26 @@ class Attribute<T> {
     }
 }
 
-@infix func == <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression == NSExpression(forConstantValue: right)
+@infix func == <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression == NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }
 
-@infix func != <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression != NSExpression(forConstantValue: right)
+@infix func != <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression != NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }
 
-@infix func > <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression > NSExpression(forConstantValue: right)
+@infix func > <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression > NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }
 
-@infix func >= <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression >= NSExpression(forConstantValue: right)
+@infix func >= <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression >= NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }
 
-@infix func < <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression < NSExpression(forConstantValue: right)
+@infix func < <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression < NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }
 
-@infix func <= <T : AnyObject>(left: Attribute<T>, right: T) -> NSPredicate {
-    return left.expression <= NSExpression(forConstantValue: right)
+@infix func <= <T>(left: Attribute<T>, right: T) -> NSPredicate {
+    return left.expression <= NSExpression(forConstantValue: bridgeToObjectiveC(right))
 }

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import QueryKit
 
 class AttributeTests: XCTestCase {
-    var attribute:Attribute<NSNumber>!
+    var attribute:Attribute<Int>!
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Uses `bridgeToObjectiveC<T>(x: T) -> AnyObject?` to allow for swift types.

Changed the Attribute tests to use `Int` to test it works correctly.
