### PR TITLE
Fix QueryKitTests-Bridging-Header.h still being referenced in build settings

### DIFF
--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -466,7 +466,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = "QueryKitTests/QueryKitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -510,7 +509,6 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = "QueryKitTests/QueryKitTests-Bridging-Header.h";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Objective-C Bridging Header setting was still set for the Tests after the file was deleted, was preventing the tests from building for me.
