### PR TITLE
QuerySet.subscript: fixed subscript from an optional

### DIFF
--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -104,7 +104,7 @@ public class QuerySet<T : NSManagedObject> : SequenceType, Equatable {
             var error:NSError?
             let items = context.executeFetchRequest(request, error:&error)
 
-            return (object:items[0] as? T, error:error)
+            return (object:items?[0] as T?, error:error)
         }
     }
 


### PR DESCRIPTION
QueryKit fails to compile with Xcode 6 beta 7 due to `executeFetchRequest` now returning an optional.

This pull request fixes this with proper optional unwrapping.
