### PR TITLE
An easier way to create QKAttribute instances

### DIFF
--- a/QueryKit/ObjectiveC/QKAttribute.h
+++ b/QueryKit/ObjectiveC/QKAttribute.h
@@ -208,3 +208,6 @@
 - (NSSortDescriptor *)descending;
 
 @end
+
+/** Returns an initialized instance of QKAttribute */
+extern inline QKAttribute * QKAttributeWithName(id name);

--- a/QueryKit/ObjectiveC/QKAttribute.m
+++ b/QueryKit/ObjectiveC/QKAttribute.m
@@ -8,6 +8,10 @@
 
 #import "QKAttribute.h"
 
+inline QKAttribute * QKAttributeWithName(id name) {
+    return [[QKAttribute alloc] initWithName:NSStringFromSelector(@selector(name))];
+}
+
 @implementation QKAttribute
 
 #pragma mark - NSCoding


### PR DESCRIPTION
Hey @kylef, how do you feel about this?

Super handy having the KFAttributeFromKey macro, this provides the same for QKAttribute but it's now an inline C function. If you've switched to only having the attributes, etc. auto-generated via your mogenerator script then you probably don't use this. For manually creating QKAttribute's this handy though and should aid in moving from KFAttribute to QKAttribute.
