### PR TITLE
Add first property for getting first object from query.

### DIFF
--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -128,6 +128,14 @@ public class QuerySet<T : NSManagedObject> : SequenceType, Equatable {
             return QuerySet(queryset:self, sortDescriptors:sortDescriptors, predicate:predicate, range:fullRange)
         }
     }
+  
+    // Mark: Getters
+    public var first: T? {
+      get {
+        return self[0].object
+      }
+    }
+  
 
     // MARK: Conversion
 

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -146,6 +146,12 @@ class QuerySetTests: XCTestCase {
         XCTAssertEqual(qs.range!.startIndex, 4)
         XCTAssertEqual(qs.range!.endIndex, 5)
     }
+  
+    //  MARK: Getters
+    func testFirst() {
+      var qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
+        XCTAssertEqual(qs.first!.name, "Ayaka")
+    }
 
     // MARK: Conversion
 


### PR DESCRIPTION
This is  convenience improvement. 

Now it's possible to do it with subscript
`let user = QuerySet<User>(moc, "User").[0]`

But I would like to have it in this way
`let user = QuerySet<User>(moc, "User").first`