### PR TITLE
Fix Join unavailable Swift Beta 6

### DIFF
--- a/QueryKit/Attribute.swift
+++ b/QueryKit/Attribute.swift
@@ -18,7 +18,7 @@ public struct Attribute<AttributeType> : Equatable {
 
   /// Builds a compound attribute with other key paths
   public init(attributes:Array<String>) {
-    self.init(".".join(attributes))
+    self.init(attributes.joinWithSeparator("."))
   }
 
   /// Returns an expression for the attribute


### PR DESCRIPTION
'join' is unavailable: call the 'joinWithSeparator()' method on the
sequence of elements