### PR TITLE
Implement type safe ordering and filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: beta-xcode6.3
+osx_image: xcode7
 before_install:
     - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
     - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/QueryKit.podspec
+++ b/QueryKit.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |spec|
   spec.source = { :git => 'https://github.com/QueryKit/QueryKit.git', :tag => "#{spec.version}" }
   spec.source_files = 'QueryKit/QueryKit.h'
   spec.requires_arc = true
-  spec.ios.deployment_target = '5.0'
-  spec.osx.deployment_target = '10.7'
+  spec.ios.deployment_target = '8.0'
+  spec.osx.deployment_target = '10.9'
 
   spec.subspec 'ObjectiveC' do |objc_spec|
     objc_spec.dependency 'QueryKit/Attribute/ObjectiveC'
@@ -20,9 +20,6 @@ Pod::Spec.new do |spec|
   spec.subspec 'Swift' do |swift_spec|
     swift_spec.dependency 'QueryKit/Attribute/Swift'
     swift_spec.dependency 'QueryKit/QuerySet/Swift'
-
-    swift_spec.ios.deployment_target = '8.0'
-    swift_spec.osx.deployment_target = '10.9'
   end
 
   spec.subspec 'Attribute' do |attribute_spec|
@@ -33,18 +30,12 @@ Pod::Spec.new do |spec|
     attribute_spec.subspec 'Swift' do |swift_spec|
       swift_spec.dependency 'QueryKit/QuerySet/Swift'
       swift_spec.source_files = 'QueryKit/{Attribute,Expression,Predicate}.swift'
-
-      swift_spec.ios.deployment_target = '8.0'
-      swift_spec.osx.deployment_target = '10.9'
     end
 
     attribute_spec.subspec 'Bridge' do |bridge_spec|
       bridge_spec.dependency 'QueryKit/Attribute/Swift'
       bridge_spec.dependency 'QueryKit/Attribute/ObjectiveC'
       bridge_spec.source_files = 'QueryKit/ObjectiveC/QKAttribute.swift'
-
-      bridge_spec.ios.deployment_target = '8.0'
-      bridge_spec.osx.deployment_target = '10.9'
     end
   end
 
@@ -55,18 +46,12 @@ Pod::Spec.new do |spec|
 
     queryset_spec.subspec 'Swift' do |swift_spec|
       swift_spec.source_files = 'QueryKit/QuerySet.swift'
-
-      swift_spec.ios.deployment_target = '8.0'
-      swift_spec.osx.deployment_target = '10.9'
     end
 
     queryset_spec.subspec 'Bridge' do |bridge_spec|
       bridge_spec.dependency 'QueryKit/QuerySet/Swift'
       bridge_spec.dependency 'QueryKit/QuerySet/ObjectiveC'
       bridge_spec.source_files = 'QueryKit/ObjectiveC/QKQuerySet.swift'
-
-      bridge_spec.ios.deployment_target = '8.0'
-      bridge_spec.osx.deployment_target = '10.9'
     end
   end
 end

--- a/QueryKit.podspec
+++ b/QueryKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'QueryKit'
-  spec.version = '0.10.0'
+  spec.version = '0.11.0-beta.1'
   spec.summary = 'A simple type-safe Core Data query language.'
   spec.homepage = 'http://querykit.org/'
   spec.license = { :type => 'BSD', :file => 'LICENSE' }

--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -269,7 +269,8 @@
 		77A9B66E1953742F0016654E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					77A9B678195374490016654E = {
 						CreatedOnToolsVersion = 6.0;
@@ -375,7 +376,9 @@
 		77A9B6721953742F0016654E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -391,7 +394,6 @@
 			baseConfigurationReference = 279294E71A4B4C60009C52E1 /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -433,6 +435,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -447,7 +450,6 @@
 			baseConfigurationReference = 279294E61A4B4C60009C52E1 /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -483,6 +485,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -530,6 +533,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "QueryKitTests/ObjectiveC/QueryKitTests-Bridging-Header.h";
@@ -570,6 +574,7 @@
 				INFOPLIST_FILE = QueryKitTests/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "QueryKitTests/ObjectiveC/QueryKitTests-Bridging-Header.h";

--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2794C8AD1B9F980100216C36 /* SortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794C8AC1B9F980100216C36 /* SortDescriptor.swift */; settings = {ASSET_TAGS = (); }; };
+		2794C8AF1B9F985900216C36 /* SortDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */; settings = {ASSET_TAGS = (); }; };
 		77007D7D19A95CDE007DC2BC /* QKQuerySetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77007D7C19A95CDE007DC2BC /* QKQuerySetTests.swift */; };
 		77007D8119A95CE9007DC2BC /* QKQuerySet.h in Headers */ = {isa = PBXBuildFile; fileRef = 77007D7E19A95CE9007DC2BC /* QKQuerySet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		77007D8219A95CE9007DC2BC /* QKQuerySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 77007D7F19A95CE9007DC2BC /* QKQuerySet.m */; };
@@ -64,6 +66,8 @@
 		279294E51A4B4C60009C52E1 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
 		279294E61A4B4C60009C52E1 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
 		279294E71A4B4C60009C52E1 /* UniversalFramework_Test.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Test.xcconfig; sourceTree = "<group>"; };
+		2794C8AC1B9F980100216C36 /* SortDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDescriptor.swift; sourceTree = "<group>"; };
+		2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDescriptorTests.swift; sourceTree = "<group>"; };
 		77007D7C19A95CDE007DC2BC /* QKQuerySetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QKQuerySetTests.swift; sourceTree = "<group>"; };
 		77007D7E19A95CE9007DC2BC /* QKQuerySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QKQuerySet.h; sourceTree = "<group>"; };
 		77007D7F19A95CE9007DC2BC /* QKQuerySet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QKQuerySet.m; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 				77E8728019539C0900A6F13F /* Attribute.swift */,
 				77E3A0601969DDF5009372A8 /* Expression.swift */,
 				77E8728619539FD200A6F13F /* Predicate.swift */,
+				2794C8AC1B9F980100216C36 /* SortDescriptor.swift */,
 				77B17B8219A94C9100D6540D /* ObjectiveC */,
 				77A9B67C195374490016654E /* Supporting Files */,
 			);
@@ -170,6 +175,7 @@
 				77E3A0621969E003009372A8 /* ExpressionTests.swift */,
 				77E8728219539C2A00A6F13F /* AttributeTests.swift */,
 				77E8728419539FC000A6F13F /* PredicateTests.swift */,
+				2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */,
 				77B17B8919A94D4C00D6540D /* ObjectiveC */,
 				77A9B689195374490016654E /* Supporting Files */,
 			);
@@ -326,6 +332,7 @@
 				77B17B8619A94C9100D6540D /* QKAttribute.m in Sources */,
 				77B17B8819A94D2C00D6540D /* QKAttribute.swift in Sources */,
 				77007D8319A95CE9007DC2BC /* QKQuerySet.swift in Sources */,
+				2794C8AD1B9F980100216C36 /* SortDescriptor.swift in Sources */,
 				77007D8219A95CE9007DC2BC /* QKQuerySet.m in Sources */,
 				77E3A05D1969C019009372A8 /* QuerySet.swift in Sources */,
 				77E3A0611969DDF5009372A8 /* Expression.swift in Sources */,
@@ -338,6 +345,7 @@
 			files = (
 				77B17B8B19A94D4C00D6540D /* QKAttributeTests.swift in Sources */,
 				77E8728319539C2A00A6F13F /* AttributeTests.swift in Sources */,
+				2794C8AF1B9F985900216C36 /* SortDescriptorTests.swift in Sources */,
 				77A9B68C195374490016654E /* QueryKitTests.swift in Sources */,
 				77007D7D19A95CDE007DC2BC /* QKQuerySetTests.swift in Sources */,
 				77E3A05F1969C047009372A8 /* QuerySetTests.swift in Sources */,

--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 				77E3A05E1969C047009372A8 /* QuerySetTests.swift */,
 				77E3A0621969E003009372A8 /* ExpressionTests.swift */,
 				77E8728219539C2A00A6F13F /* AttributeTests.swift */,
+				77E8728419539FC000A6F13F /* PredicateTests.swift */,
 				77B17B8919A94D4C00D6540D /* ObjectiveC */,
 				77A9B689195374490016654E /* Supporting Files */,
 			);
@@ -178,7 +179,6 @@
 		77A9B689195374490016654E /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				77E8728419539FC000A6F13F /* PredicateTests.swift */,
 				77A9B68A195374490016654E /* Info.plist */,
 			);
 			name = "Supporting Files";

--- a/QueryKit.xcodeproj/xcshareddata/xcschemes/QueryKit.xcscheme
+++ b/QueryKit.xcodeproj/xcshareddata/xcschemes/QueryKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:QueryKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/QueryKit/Attribute.swift
+++ b/QueryKit/Attribute.swift
@@ -95,7 +95,7 @@ public func ~= <AttributeType>(left: Attribute<AttributeType>, right: AttributeT
 }
 
 public func << <AttributeType>(left: Attribute<AttributeType>, right: [AttributeType]) -> NSPredicate {
-    let value = map(right) { value in return value as! NSObject }
+    let value = right.map { value in return value as! NSObject }
     return left.expression << NSExpression(forConstantValue: value)
 }
 
@@ -103,7 +103,7 @@ public func << <AttributeType>(left: Attribute<AttributeType>, right: Range<Attr
     let value = [right.startIndex as! NSObject, right.endIndex as! NSObject] as NSArray
     let rightExpression = NSExpression(forConstantValue: value)
 
-  return NSComparisonPredicate(leftExpression: left.expression, rightExpression: rightExpression, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.BetweenPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left.expression, rightExpression: rightExpression, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.BetweenPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 /// MARK: Bool Attributes

--- a/QueryKit/Expression.swift
+++ b/QueryKit/Expression.swift
@@ -10,34 +10,34 @@ import Foundation
 
 /// Returns an equality predicate for the two given expressions
 public func == (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.EqualToPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.EqualToPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 /// Returns an inequality predicate for the two given expressions
 public func != (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.NotEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.NotEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func > (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.GreaterThanPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.GreaterThanPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func >= (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.GreaterThanOrEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.GreaterThanOrEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func < (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LessThanPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LessThanPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func <= (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LessThanOrEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LessThanOrEqualToPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func ~= (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LikePredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.LikePredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }
 
 public func << (left: NSExpression, right: NSExpression) -> NSPredicate {
-  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.InPredicateOperatorType, options: NSComparisonPredicateOptions(0))
+  return NSComparisonPredicate(leftExpression: left, rightExpression: right, modifier: NSComparisonPredicateModifier.DirectPredicateModifier, type: NSPredicateOperatorType.InPredicateOperatorType, options: NSComparisonPredicateOptions(rawValue: 0))
 }

--- a/QueryKit/Info.plist
+++ b/QueryKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocode.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QueryKit/ObjectiveC/QKAttribute.swift
+++ b/QueryKit/ObjectiveC/QKAttribute.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Attribute {
   public func asQKAttribute() -> QKAttribute {
-    return QKAttribute(name: name)
+    return QKAttribute(name: key)
   }
 }
 

--- a/QueryKit/Predicate.swift
+++ b/QueryKit/Predicate.swift
@@ -34,31 +34,31 @@ public struct Predicate<ModelType : NSManagedObject> {
   }
 }
 
-public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left == right)
 }
 
-public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left != right)
 }
 
-public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left > right)
 }
 
-public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left >= right)
 }
 
-public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left < right)
 }
 
-public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left <= right)
 }
 
-public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left ~= right)
 }
 

--- a/QueryKit/Predicate.swift
+++ b/QueryKit/Predicate.swift
@@ -22,3 +22,65 @@ public func || (left: NSPredicate, right: NSPredicate) -> NSPredicate {
 prefix public func ! (left: NSPredicate) -> NSPredicate {
   return NSCompoundPredicate(type: NSCompoundPredicateType.NotPredicateType, subpredicates: [left])
 }
+
+// MARK: Predicate Type
+
+/// Represents a predicate for a specific model
+public struct Predicate<ModelType : NSManagedObject> {
+  let predicate:NSPredicate
+
+  init(predicate:NSPredicate) {
+    self.predicate = predicate
+  }
+}
+
+public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left == right)
+}
+
+public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left != right)
+}
+
+public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left > right)
+}
+
+public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left >= right)
+}
+
+public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left < right)
+}
+
+public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left <= right)
+}
+
+public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left ~= right)
+}
+
+public func << <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: [AttributeType]) -> Predicate<T> {
+  return Predicate(predicate: left << right)
+}
+
+public func << <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: Range<AttributeType>) -> Predicate<T> {
+  return Predicate(predicate: left << right)
+}
+
+/// Returns an and predicate from the given predicates
+public func && <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: left.predicate && right.predicate)
+}
+
+/// Returns an or predicate from the given predicates
+public func || <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: left.predicate || right.predicate)
+}
+
+/// Returns a predicate reversing the given predicate
+prefix public func ! <T>(predicate: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: !predicate.predicate)
+}

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -69,6 +69,18 @@ extension QuerySet {
     return QuerySet(queryset:self, sortDescriptors:sortDescriptors.map(reverseSortDescriptor), predicate:predicate, range:range)
   }
 
+  // MARK: Type-safe Sorting
+
+  ///  Returns a new QuerySet containing objects ordered by the given sort descriptor.
+  public func orderBy(closure:((ModelType.Type) -> (SortDescriptor<ModelType>))) -> QuerySet<ModelType> {
+    return orderBy(closure(ModelType.self).sortDescriptor)
+  }
+
+  /// Returns a new QuerySet containing objects ordered by the given sort descriptors.
+  public func orderBy(closure:((ModelType.Type) -> ([SortDescriptor<ModelType>]))) -> QuerySet<ModelType> {
+    return orderBy(closure(ModelType.self).map { $0.sortDescriptor })
+  }
+
   // MARK: Filtering
 
   /// Returns a new QuerySet containing objects that match the given predicate.

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -99,6 +99,28 @@ extension QuerySet {
     let excludePredicate = NSCompoundPredicate(type: NSCompoundPredicateType.AndPredicateType, subpredicates: predicates)
     return exclude(excludePredicate)
   }
+
+  // MARK: Type-safe filtering
+
+  /// Returns a new QuerySet containing objects that match the given predicate.
+  public func filter(closure:((ModelType.Type) -> (Predicate<ModelType>))) -> QuerySet<ModelType> {
+    return filter(closure(ModelType.self).predicate)
+  }
+
+  /// Returns a new QuerySet containing objects that exclude the given predicate.
+  public func exclude(closure:((ModelType.Type) -> (Predicate<ModelType>))) -> QuerySet<ModelType> {
+    return exclude(closure(ModelType.self).predicate)
+  }
+
+  /// Returns a new QuerySet containing objects that match the given predicatess.
+  public func filter(closures:[((ModelType.Type) -> (Predicate<ModelType>))]) -> QuerySet<ModelType> {
+    return filter(closures.map { $0(ModelType.self).predicate })
+  }
+
+  /// Returns a new QuerySet containing objects that exclude the given predicates.
+  public func exclude(closures:[((ModelType.Type) -> (Predicate<ModelType>))]) -> QuerySet<ModelType> {
+    return exclude(closures.map { $0(ModelType.self).predicate })
+  }
 }
 
 /// Functions for evauluating a QuerySet

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -9,11 +9,6 @@
 import Foundation
 import CoreData
 
-#if os(OSX) && COCOAPODS
-  import AppKit
-#endif
-
-
 /// Represents a lazy database lookup for a set of objects.
 public class QuerySet<ModelType : NSManagedObject> : SequenceType, Equatable {
   /// Returns the managed object context that will be used to execute any requests.
@@ -66,11 +61,7 @@ extension QuerySet {
   /// Reverses the ordering of the QuerySet
   public func reverse() -> QuerySet<ModelType> {
     func reverseSortDescriptor(sortDescriptor:NSSortDescriptor) -> NSSortDescriptor {
-      #if os(OSX) && COCOAPODS
-        return NSSortDescriptor(key: sortDescriptor.key()!, ascending: !sortDescriptor.ascending)
-        #else
-        return NSSortDescriptor(key: sortDescriptor.key!, ascending: !sortDescriptor.ascending)
-      #endif
+      return NSSortDescriptor(key: sortDescriptor.key!, ascending: !sortDescriptor.ascending)
     }
 
     return QuerySet(queryset:self, sortDescriptors:sortDescriptors.map(reverseSortDescriptor), predicate:predicate, range:range)

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 /// Represents a lazy database lookup for a set of objects.
-public class QuerySet<ModelType : NSManagedObject> : Equatable, SequenceType {
+public class QuerySet<ModelType : NSManagedObject> : Equatable {
   /// Returns the managed object context that will be used to execute any requests.
   public let context:NSManagedObjectContext
 
@@ -230,17 +230,6 @@ extension QuerySet {
     }
 
     return deletedCount
-  }
-
-  // MARK: Sequence
-
-  public func generate() -> IndexingGenerator<Array<ModelType>> {
-    do {
-      let generator = try self.array().generate()
-      return generator
-    } catch {
-      return [].generate()
-    }
   }
 }
 

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 /// Represents a lazy database lookup for a set of objects.
-public class QuerySet<ModelType : NSManagedObject> : SequenceType, Equatable {
+public class QuerySet<ModelType : NSManagedObject> : Equatable, SequenceType {
   /// Returns the managed object context that will be used to execute any requests.
   public let context:NSManagedObjectContext
 

--- a/QueryKit/SortDescriptor.swift
+++ b/QueryKit/SortDescriptor.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Represents a sort descriptor for a specific model
+public struct SortDescriptor<ModelType : NSManagedObject> {
+  let sortDescriptor:NSSortDescriptor
+
+  init(sortDescriptor:NSSortDescriptor) {
+    self.sortDescriptor = sortDescriptor
+  }
+}
+
+extension Attribute {
+  /// Returns an ascending sort descriptor for the attribute
+  public func ascending<T : NSManagedObject>() -> SortDescriptor<T> {
+    return SortDescriptor(sortDescriptor: ascending())
+  }
+
+  /// Returns a descending sort descriptor for the attribute
+  public func descending<T : NSManagedObject>() -> SortDescriptor<T> {
+    return SortDescriptor(sortDescriptor: descending())
+  }
+}

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -17,8 +17,8 @@ class AttributeTests: XCTestCase {
     attribute = Attribute("age")
   }
 
-  func testAttributeHasName() {
-    XCTAssertEqual(attribute.name, "age")
+  func testAttributeHasKey() {
+    XCTAssertEqual(attribute.key, "age")
   }
 
   func testAttributeExpression() {
@@ -32,7 +32,7 @@ class AttributeTests: XCTestCase {
   func testCompoundAttributeCreation() {
     let personCompanyNameAttribute = Attribute<NSString>(attributes:["company", "name"])
 
-    XCTAssertEqual(personCompanyNameAttribute.name, "company.name")
+    XCTAssertEqual(personCompanyNameAttribute.key, "company.name")
     XCTAssertEqual(personCompanyNameAttribute.expression.keyPath, "company.name")
   }
 

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -14,7 +14,6 @@ class AttributeTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-
     attribute = Attribute("age")
   }
 

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -50,59 +50,59 @@ class AttributeTests: XCTestCase {
   // Operators
 
   func testEqualityOperator() {
-    var predicate:NSPredicate = (attribute == 10)
+    let predicate:NSPredicate = (attribute == 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age == 10"))
   }
 
   func testInequalityOperator() {
-    var predicate:NSPredicate = (attribute != 10)
+    let predicate:NSPredicate = (attribute != 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age != 10"))
   }
 
   func testGreaterThanOperator() {
-    var predicate:NSPredicate = (attribute > 10)
+    let predicate:NSPredicate = (attribute > 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age > 10"))
   }
 
   func testGreaterOrEqualThanOperator() {
-    var predicate:NSPredicate = (attribute >= 10)
+    let predicate:NSPredicate = (attribute >= 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age >= 10"))
   }
 
   func testLessThanOperator() {
-    var predicate:NSPredicate = (attribute < 10)
+    let predicate:NSPredicate = (attribute < 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age < 10"))
   }
 
   func testLessOrEqualThanOperator() {
-    var predicate:NSPredicate = (attribute <= 10)
+    let predicate:NSPredicate = (attribute <= 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age <= 10"))
   }
 
   func testLikeOperator() {
-    var predicate:NSPredicate = (attribute ~= 10)
+    let predicate:NSPredicate = (attribute ~= 10)
     XCTAssertEqual(predicate, NSPredicate(format:"age LIKE 10"))
   }
 
   func testInOperator() {
-    var predicate:NSPredicate = (attribute << [5, 10])
+    let predicate:NSPredicate = (attribute << [5, 10])
     XCTAssertEqual(predicate, NSPredicate(format:"age IN %@", [5, 10]))
   }
 
   func testBetweenRangeOperator() {
-    var predicate:NSPredicate = attribute << (5..<10)
+    let predicate:NSPredicate = attribute << (5..<10)
     XCTAssertEqual(predicate, NSPredicate(format:"age BETWEEN %@", [5, 10]))
   }
 
   func testOptionalEqualityOperator() {
     let attribute = Attribute<String?>("name")
-    var predicate:NSPredicate = (attribute == "kyle")
+    let predicate:NSPredicate = (attribute == "kyle")
     XCTAssertEqual(predicate, NSPredicate(format:"name == 'kyle'"))
   }
 
   func testOptionalNSObjectEqualityOperator() {
     let attribute = Attribute<NSString?>("name")
-    var predicate:NSPredicate = (attribute == "kyle")
+    let predicate:NSPredicate = (attribute == "kyle")
     XCTAssertEqual(predicate, NSPredicate(format:"name == 'kyle'"))
   }
 }

--- a/QueryKitTests/Info.plist
+++ b/QueryKitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocode.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QueryKitTests/PredicateTests.swift
+++ b/QueryKitTests/PredicateTests.swift
@@ -86,14 +86,8 @@ class PredicateTests: XCTestCase {
     XCTAssertEqual(predicate.predicate, NSPredicate(format:"age BETWEEN %@", [5, 10]))
   }
 
-  func testOptionalEqualityOperator() {
-    let attribute = Attribute<String?>("name")
-    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
-    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
-  }
-
-  func testOptionalNSObjectEqualityOperator() {
-    let attribute = Attribute<NSString?>("name")
+  func testNSObjectEqualityOperator() {
+    let attribute = Attribute<NSString>("name")
     let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
     XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
   }

--- a/QueryKitTests/PredicateTests.swift
+++ b/QueryKitTests/PredicateTests.swift
@@ -7,24 +7,114 @@
 //
 
 import XCTest
-import QueryKit
+@testable import QueryKit
+
+
+class NSPredicateTests: XCTestCase {
+  var namePredicate = NSPredicate(format: "name == Kyle")
+  var agePredicate = NSPredicate(format: "age >= 21")
+
+  func testAndPredicate() {
+    let predicate = namePredicate && agePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
+  }
+
+  func testOrPredicate() {
+    let predicate = namePredicate || agePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
+  }
+
+  func testNotPredicate() {
+    let predicate = !namePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "NOT name == Kyle"))
+  }
+}
+
 
 class PredicateTests: XCTestCase {
-    var namePredicate = NSPredicate(format: "name == Kyle")
-    var agePredicate = NSPredicate(format: "age >= 21")
+  var attribute:Attribute<Int>!
 
-    func testAndPredicate() {
-        let predicate = namePredicate && agePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
-    }
+  override func setUp() {
+    super.setUp()
+    attribute = Attribute("age")
+  }
 
-    func testOrPredicate() {
-        let predicate = namePredicate || agePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
-    }
+  // MARK: Operators
 
-    func testNotPredicate() {
-        let predicate = !namePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "NOT name == Kyle"))
-    }
+  func testEqualityOperator() {
+    let predicate:Predicate<NSManagedObject> = attribute == 10
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age == 10"))
+  }
+
+  func testInequalityOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute != 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age != 10"))
+  }
+
+  func testGreaterThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute > 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age > 10"))
+  }
+
+  func testGreaterOrEqualThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute >= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age >= 10"))
+  }
+
+  func testLessThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute < 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age < 10"))
+  }
+
+  func testLessOrEqualThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute <= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age <= 10"))
+  }
+
+  func testLikeOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute ~= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age LIKE 10"))
+  }
+
+  func testInOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute << [5, 10])
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age IN %@", [5, 10]))
+  }
+
+  func testBetweenRangeOperator() {
+    let predicate:Predicate<NSManagedObject> = attribute << (5..<10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age BETWEEN %@", [5, 10]))
+  }
+
+  func testOptionalEqualityOperator() {
+    let attribute = Attribute<String?>("name")
+    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  func testOptionalNSObjectEqualityOperator() {
+    let attribute = Attribute<NSString?>("name")
+    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  // MARK:
+
+  var namePredicate = Predicate<NSManagedObject>(predicate: NSPredicate(format: "name == Kyle"))
+  var agePredicate = Predicate<NSManagedObject>(predicate: NSPredicate(format: "age >= 21"))
+
+  func testAndPredicate() {
+    let predicate = namePredicate && agePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
+  }
+
+  func testOrPredicate() {
+    let predicate = namePredicate || agePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
+  }
+
+  func testNotPredicate() {
+    let predicate = !namePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "NOT name == Kyle"))
+  }
 }

--- a/QueryKitTests/PredicateTests.swift
+++ b/QueryKitTests/PredicateTests.swift
@@ -14,17 +14,17 @@ class PredicateTests: XCTestCase {
     var agePredicate = NSPredicate(format: "age >= 21")
 
     func testAndPredicate() {
-        var predicate = namePredicate && agePredicate
+        let predicate = namePredicate && agePredicate
         XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
     }
 
     func testOrPredicate() {
-        var predicate = namePredicate || agePredicate
+        let predicate = namePredicate || agePredicate
         XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
     }
 
     func testNotPredicate() {
-        var predicate = !namePredicate
+        let predicate = !namePredicate
         XCTAssertEqual(predicate, NSPredicate(format: "NOT name == Kyle"))
     }
 }

--- a/QueryKitTests/QueryKitTests.swift
+++ b/QueryKitTests/QueryKitTests.swift
@@ -44,6 +44,26 @@ func managedObjectModel() -> NSManagedObjectModel {
 func persistentStoreCoordinator() -> NSPersistentStoreCoordinator {
   let model = managedObjectModel()
   let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-  persistentStoreCoordinator.addPersistentStoreWithType(NSInMemoryStoreType, configuration: nil, URL: nil, options: nil, error: nil)
+  do {
+    try persistentStoreCoordinator.addPersistentStoreWithType(NSInMemoryStoreType, configuration: nil, URL: nil, options: nil)
+  } catch _ {
+  }
   return persistentStoreCoordinator
+}
+
+public func AssertNotThrow<R>(@autoclosure closure: () throws -> R) -> R? {
+  var result: R?
+  AssertNotThrow() {
+    result = try closure()
+  }
+  return result
+}
+
+public func AssertNotThrow(@noescape closure: () throws -> ()) {
+  do {
+    try closure()
+  } catch let error {
+    XCTFail("Catched error \(error), "
+      + "but did not expect any error.")
+  }
 }

--- a/QueryKitTests/QueryKitTests.swift
+++ b/QueryKitTests/QueryKitTests.swift
@@ -12,6 +12,7 @@ import CoreData
 
 @objc(Person) class Person : NSManagedObject {
   @NSManaged var name:String
+  @NSManaged var company:Company?
 
   class var entityName:String {
     return "Person"
@@ -19,6 +20,32 @@ import CoreData
 
   class var name:Attribute<String> {
     return Attribute("name")
+  }
+
+  class var company:Attribute<Company> {
+    return Attribute("company")
+  }
+}
+
+@objc(Company) class Company : NSManagedObject {
+  @NSManaged var name:String
+
+  class var entityName:String {
+    return "Company"
+  }
+
+  class var name:Attribute<String> {
+    return Attribute("name")
+  }
+
+  class func create(context:NSManagedObjectContext) -> Company {
+    return NSEntityDescription.insertNewObjectForEntityForName(Company.entityName, inManagedObjectContext: context) as! Company
+  }
+}
+
+extension Attribute where AttributeType: Company {
+  var name:Attribute<String> {
+    return attribute(AttributeType.name)
   }
 }
 
@@ -29,18 +56,43 @@ extension Person {
 }
 
 func managedObjectModel() -> NSManagedObjectModel {
+  let companyEntity = NSEntityDescription()
+  companyEntity.name = Company.entityName
+  companyEntity.managedObjectClassName = "Company"
+
   let personEntity = NSEntityDescription()
   personEntity.name = Person.entityName
   personEntity.managedObjectClassName = "Person"
+
+  let companyNameAttribute = NSAttributeDescription()
+  companyNameAttribute.name = "name"
+  companyNameAttribute.attributeType = NSAttributeType.StringAttributeType
+  companyNameAttribute.optional = false
+
+  let companyPeopleAttribute = NSRelationshipDescription()
+  companyPeopleAttribute.name = "members"
+  companyPeopleAttribute.maxCount = 0
+  companyPeopleAttribute.destinationEntity = personEntity
 
   let personNameAttribute = NSAttributeDescription()
   personNameAttribute.name = "name"
   personNameAttribute.attributeType = NSAttributeType.StringAttributeType
   personNameAttribute.optional = false
-  personEntity.properties = [personNameAttribute]
+
+  let personCompanyRelation = NSRelationshipDescription()
+  personCompanyRelation.name = "company"
+  personCompanyRelation.destinationEntity = companyEntity
+  personCompanyRelation.maxCount = 1
+  personCompanyRelation.optional = true
+
+  companyPeopleAttribute.inverseRelationship = personCompanyRelation
+  personCompanyRelation.inverseRelationship = companyPeopleAttribute
+
+  companyEntity.properties = [companyNameAttribute, companyPeopleAttribute]
+  personEntity.properties = [personNameAttribute, personCompanyRelation]
 
   let model = NSManagedObjectModel()
-  model.entities = [personEntity]
+  model.entities = [personEntity, companyEntity]
 
   return model
 }
@@ -50,7 +102,9 @@ func persistentStoreCoordinator() -> NSPersistentStoreCoordinator {
   let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
   do {
     try persistentStoreCoordinator.addPersistentStoreWithType(NSInMemoryStoreType, configuration: nil, URL: nil, options: nil)
-  } catch _ {
+  } catch {
+    print(error)
+    fatalError()
   }
   return persistentStoreCoordinator
 }

--- a/QueryKitTests/QueryKitTests.swift
+++ b/QueryKitTests/QueryKitTests.swift
@@ -16,6 +16,10 @@ import CoreData
   class var entityName:String {
     return "Person"
   }
+
+  class var name:Attribute<String> {
+    return Attribute("name")
+  }
 }
 
 extension Person {

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import CoreData
 import QueryKit
 
+
 class QuerySetTests: XCTestCase {
   var context:NSManagedObjectContext!
   var queryset:QuerySet<Person>!
@@ -80,6 +81,12 @@ class QuerySetTests: XCTestCase {
     XCTAssertEqual(qs.predicate!, NSPredicate(format: "isEmployed == YES"))
   }
 
+  func testTypeSafeFilter() {
+    let qs = queryset.filter { $0.name == "Kyle" }
+
+    XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
+  }
+
   // MARK: Exclusion
 
   func testExcludePredicate() {
@@ -99,6 +106,12 @@ class QuerySetTests: XCTestCase {
   func testExcludeBooleanAttribute() {
     let qs = queryset.exclude(Attribute<Bool>("isEmployed"))
     XCTAssertEqual(qs.predicate!, NSPredicate(format: "isEmployed == NO"))
+  }
+
+  func testTypeSafeExclude() {
+    let qs = queryset.exclude { $0.name == "Kyle" }
+
+    XCTAssertEqual(qs.predicate?.description, "NOT name == \"Kyle\"")
   }
 
   // Fetch Request

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -49,6 +49,17 @@ class QuerySetTests: XCTestCase {
     XCTAssertTrue(qs.sortDescriptors == [sortDescriptor])
   }
 
+  func testTypeSafeOrderBySortDescriptor() {
+    let qs = queryset.orderBy { $0.name.ascending() }
+    XCTAssertTrue(qs.sortDescriptors == [NSSortDescriptor(key: "name", ascending: true)])
+  }
+
+  func testTypeSafeOrderBySortDescriptors() {
+    let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+    let qs = queryset.orderBy { [$0.name.ascending()] }
+    XCTAssertTrue(qs.sortDescriptors == [sortDescriptor])
+  }
+
   func testReverseOrdering() {
     let nameSortDescriptor = NSSortDescriptor(key: "name", ascending: true)
     let ageSortDescriptor = NSSortDescriptor(key: "age", ascending: true)

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -100,7 +100,7 @@ class QuerySetTests: XCTestCase {
   }
 
   func testTypeSafeFilter() {
-    let qs:QuerySet<Person> = queryset.filter { $0.name == "Kyle" }
+    let qs = queryset.filter { $0.name == "Kyle" }
 
     XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
   }
@@ -248,18 +248,5 @@ class QuerySetTests: XCTestCase {
 
     XCTAssertEqual(deletedCount, 2)
     XCTAssertEqual(count, 3)
-  }
-
-  // MARK: Sequence
-
-  func testSequence() {
-    let qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
-    var objects = [Person]()
-
-    for object in qs {
-      objects.append(object)
-    }
-
-    XCTAssertEqual(objects.count, 5)
   }
 }

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -25,10 +25,7 @@ class QuerySetTests: XCTestCase {
       person.name = name
     }
 
-    do {
-      try context.save()
-    } catch _ {
-    }
+    try! context.save()
 
     queryset = QuerySet(context, "Person")
   }
@@ -59,7 +56,7 @@ class QuerySetTests: XCTestCase {
     XCTAssertEqual(qs.sortDescriptors, [
       NSSortDescriptor(key: "name", ascending: false),
       NSSortDescriptor(key: "age", ascending: false),
-      ])
+    ])
   }
 
   // MARK: Filtering
@@ -125,11 +122,11 @@ class QuerySetTests: XCTestCase {
   func testSubscriptingAtIndex() {
     let qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
 
-    let ayaka = qs[0].object
-    let kyle = qs[1].object
-    let mark = qs[2].object
-    let orta:Person? = qs[3].object
-    let scott:Person? = qs[4]
+    let ayaka = try! qs.object(0)
+    let kyle = try! qs.object(1)
+    let mark = try! qs.object(2)
+    let orta = try! qs.object(3)
+    let scott = try! qs.object(4)
 
     XCTAssertEqual(ayaka!.name, "Ayaka")
     XCTAssertEqual(kyle!.name, "Kyle")
@@ -158,12 +155,14 @@ class QuerySetTests: XCTestCase {
 
   func testFirst() {
     let qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
-    XCTAssertEqual(qs.first!.name, "Ayaka")
+    let name = try! qs.first()?.name
+    XCTAssertEqual(name, "Ayaka")
   }
 
   func testLast() {
     let qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
-    XCTAssertEqual(qs.last!.name, "Scott")
+    let name = try! qs.last()?.name
+    XCTAssertEqual(name, "Scott")
   }
 
   // MARK: Conversion

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -21,9 +21,16 @@ class QuerySetTests: XCTestCase {
     context = NSManagedObjectContext()
     context.persistentStoreCoordinator = persistentStoreCoordinator()
 
+    let company = Company.create(context)
+    company.name = "Cocode"
+
     for name in ["Kyle", "Orta", "Ayaka", "Mark", "Scott"] {
       let person = Person.create(context)
       person.name = name
+
+      if name == "Kyle" {
+        person.company == "Cocode"
+      }
     }
 
     try! context.save()
@@ -93,9 +100,17 @@ class QuerySetTests: XCTestCase {
   }
 
   func testTypeSafeFilter() {
-    let qs = queryset.filter { $0.name == "Kyle" }
+    let qs:QuerySet<Person> = queryset.filter { $0.name == "Kyle" }
 
     XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
+  }
+
+  func testTypeSafeRelatedFilterPredicate() {
+    let at = Attribute<Company>("company")
+    XCTAssertEqual(at.name.key, "company.name")
+    let qs = queryset.filter { $0.company.name == "Cocode" }
+
+    XCTAssertEqual(qs.predicate?.description, "company.name == \"Cocode\"")
   }
 
   // MARK: Exclusion

--- a/QueryKitTests/SortDescriptorTests.swift
+++ b/QueryKitTests/SortDescriptorTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import QueryKit
+
+class SortDescriptorTests: XCTestCase {
+  var attribute:Attribute<Int>!
+
+  override func setUp() {
+    super.setUp()
+    attribute = Attribute("age")
+  }
+
+  func testAscendingSortDescriptor() {
+    let sortDescriptor:SortDescriptor<NSManagedObject> = attribute.ascending()
+    XCTAssertEqual(sortDescriptor.sortDescriptor, NSSortDescriptor(key: "age", ascending: true))
+  }
+
+  func testDescendingSortDescriptor() {
+    let sortDescriptor:SortDescriptor<NSManagedObject> = attribute.descending()
+    XCTAssertEqual(sortDescriptor.sortDescriptor, NSSortDescriptor(key: "age", ascending: false))
+  }
+}

--- a/README.md
+++ b/README.md
@@ -91,18 +91,12 @@ queryset[0..5]
 
 ##### Multiple objects
 
-A QuerySet is utterable, and it executes the query when you iterate over it. For example:
+You can convert a QuerySet to an array using the `array()` function. For example:
 
 ```swift
-for person in queryset {
+for person in try! queryset.array() {
   println("Hello \(person.name).")
 }
-```
-
-You can also convert the QuerySet to an Array:
-
-```swift
-queryset.array()
 ```
 
 ##### First object

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 
 QueryKit, a simple type-safe Core Data query language.
 
-## Installation
-
-```ruby
-pod 'QueryKit'
-```
-
 ## Usage
 
 ### QuerySet
@@ -21,13 +15,13 @@ A QuerySet represents a collection of objects from your Core Data Store. It can 
 #### Retrieving all objects
 
 ```swift
-QuerySet(context, "Person")
+let queryset = QuerySet(context, "Person")
 ```
 
 **NOTE**: *It’s recommend to implement a type type-safe `queryset` method on your model.*
 
 ```swift
-Person.queryset(context)
+let queryset = Person.queryset(context)
 ```
 
 #### Retrieving specific objects with filters
@@ -114,19 +108,19 @@ queryset.array()
 ##### First object
 
 ```swift
-var kyle = Person.queryset(context).filter(Person.name == "Kyle").first
+var kyle = Person.queryset(context).filter(Person.name == "Kyle").first()
 ```
 
 ##### Last object
 
 ```swift
-var kyle = Person.queryset(context).filter(Person.name == "Kyle").last
+var kyle = Person.queryset(context).filter(Person.name == "Kyle").last()
 ```
 
 ##### Object at index
 
 ```swift
-var orta = queryset[3]
+var orta = queryset.object(3)
 ```
 
 ##### Count
@@ -189,6 +183,12 @@ NSPredicate(format:"age >= 21") && !NSPredicate(format:"name == Kyle")
 ```swift
 Person.name == "Kyle" || Person.name == "Katie"
 Person.age >= 21 || Person.name != "Kyle"
+```
+
+## Installation
+
+```ruby
+pod 'QueryKit'
 ```
 
 ## License


### PR DESCRIPTION
This pull request introduces the ability to do type-safe filtering and sorting, for example:

```swift
Person.queryset(context)
  .filter { $0.company.name == "Cocode" }
  .orderBy { $0.name }
```

Providing you create the attribute extensions:

```swift
extension Person {
  class var name:Attribute<String> { return Attribute("name") }
  class var company:Attribute<Company> { return Attribute("company") }
}

extension Company {
  class var name:Attribute<String> { return Attribute("name") }
}

extension Attribute where AttributeType: Company {
  var name:Attribute<String> { return attribute(AttributeType.name) }
}
```