### PR TITLE
Implement type safe ordering and filtering

### DIFF
--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2794C8AD1B9F980100216C36 /* SortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794C8AC1B9F980100216C36 /* SortDescriptor.swift */; settings = {ASSET_TAGS = (); }; };
+		2794C8AF1B9F985900216C36 /* SortDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */; settings = {ASSET_TAGS = (); }; };
 		77007D7D19A95CDE007DC2BC /* QKQuerySetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77007D7C19A95CDE007DC2BC /* QKQuerySetTests.swift */; };
 		77007D8119A95CE9007DC2BC /* QKQuerySet.h in Headers */ = {isa = PBXBuildFile; fileRef = 77007D7E19A95CE9007DC2BC /* QKQuerySet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		77007D8219A95CE9007DC2BC /* QKQuerySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 77007D7F19A95CE9007DC2BC /* QKQuerySet.m */; };
@@ -64,6 +66,8 @@
 		279294E51A4B4C60009C52E1 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
 		279294E61A4B4C60009C52E1 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
 		279294E71A4B4C60009C52E1 /* UniversalFramework_Test.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Test.xcconfig; sourceTree = "<group>"; };
+		2794C8AC1B9F980100216C36 /* SortDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDescriptor.swift; sourceTree = "<group>"; };
+		2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortDescriptorTests.swift; sourceTree = "<group>"; };
 		77007D7C19A95CDE007DC2BC /* QKQuerySetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QKQuerySetTests.swift; sourceTree = "<group>"; };
 		77007D7E19A95CE9007DC2BC /* QKQuerySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QKQuerySet.h; sourceTree = "<group>"; };
 		77007D7F19A95CE9007DC2BC /* QKQuerySet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QKQuerySet.m; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 				77E8728019539C0900A6F13F /* Attribute.swift */,
 				77E3A0601969DDF5009372A8 /* Expression.swift */,
 				77E8728619539FD200A6F13F /* Predicate.swift */,
+				2794C8AC1B9F980100216C36 /* SortDescriptor.swift */,
 				77B17B8219A94C9100D6540D /* ObjectiveC */,
 				77A9B67C195374490016654E /* Supporting Files */,
 			);
@@ -170,6 +175,7 @@
 				77E3A0621969E003009372A8 /* ExpressionTests.swift */,
 				77E8728219539C2A00A6F13F /* AttributeTests.swift */,
 				77E8728419539FC000A6F13F /* PredicateTests.swift */,
+				2794C8AE1B9F985900216C36 /* SortDescriptorTests.swift */,
 				77B17B8919A94D4C00D6540D /* ObjectiveC */,
 				77A9B689195374490016654E /* Supporting Files */,
 			);
@@ -326,6 +332,7 @@
 				77B17B8619A94C9100D6540D /* QKAttribute.m in Sources */,
 				77B17B8819A94D2C00D6540D /* QKAttribute.swift in Sources */,
 				77007D8319A95CE9007DC2BC /* QKQuerySet.swift in Sources */,
+				2794C8AD1B9F980100216C36 /* SortDescriptor.swift in Sources */,
 				77007D8219A95CE9007DC2BC /* QKQuerySet.m in Sources */,
 				77E3A05D1969C019009372A8 /* QuerySet.swift in Sources */,
 				77E3A0611969DDF5009372A8 /* Expression.swift in Sources */,
@@ -338,6 +345,7 @@
 			files = (
 				77B17B8B19A94D4C00D6540D /* QKAttributeTests.swift in Sources */,
 				77E8728319539C2A00A6F13F /* AttributeTests.swift in Sources */,
+				2794C8AF1B9F985900216C36 /* SortDescriptorTests.swift in Sources */,
 				77A9B68C195374490016654E /* QueryKitTests.swift in Sources */,
 				77007D7D19A95CDE007DC2BC /* QKQuerySetTests.swift in Sources */,
 				77E3A05F1969C047009372A8 /* QuerySetTests.swift in Sources */,

--- a/QueryKit.xcodeproj/project.pbxproj
+++ b/QueryKit.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 				77E3A05E1969C047009372A8 /* QuerySetTests.swift */,
 				77E3A0621969E003009372A8 /* ExpressionTests.swift */,
 				77E8728219539C2A00A6F13F /* AttributeTests.swift */,
+				77E8728419539FC000A6F13F /* PredicateTests.swift */,
 				77B17B8919A94D4C00D6540D /* ObjectiveC */,
 				77A9B689195374490016654E /* Supporting Files */,
 			);
@@ -178,7 +179,6 @@
 		77A9B689195374490016654E /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				77E8728419539FC000A6F13F /* PredicateTests.swift */,
 				77A9B68A195374490016654E /* Info.plist */,
 			);
 			name = "Supporting Files";

--- a/QueryKit/ObjectiveC/QKAttribute.swift
+++ b/QueryKit/ObjectiveC/QKAttribute.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Attribute {
   public func asQKAttribute() -> QKAttribute {
-    return QKAttribute(name: name)
+    return QKAttribute(name: key)
   }
 }
 

--- a/QueryKit/Predicate.swift
+++ b/QueryKit/Predicate.swift
@@ -34,31 +34,31 @@ public struct Predicate<ModelType : NSManagedObject> {
   }
 }
 
-public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left == right)
 }
 
-public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left != right)
 }
 
-public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left > right)
 }
 
-public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left >= right)
 }
 
-public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left < right)
 }
 
-public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left <= right)
 }
 
-public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> Predicate<T> {
   return Predicate(predicate: left ~= right)
 }
 

--- a/QueryKit/Predicate.swift
+++ b/QueryKit/Predicate.swift
@@ -22,3 +22,65 @@ public func || (left: NSPredicate, right: NSPredicate) -> NSPredicate {
 prefix public func ! (left: NSPredicate) -> NSPredicate {
   return NSCompoundPredicate(type: NSCompoundPredicateType.NotPredicateType, subpredicates: [left])
 }
+
+// MARK: Predicate Type
+
+/// Represents a predicate for a specific model
+public struct Predicate<ModelType : NSManagedObject> {
+  let predicate:NSPredicate
+
+  init(predicate:NSPredicate) {
+    self.predicate = predicate
+  }
+}
+
+public func == <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left == right)
+}
+
+public func != <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left != right)
+}
+
+public func > <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left > right)
+}
+
+public func >= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left >= right)
+}
+
+public func < <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left < right)
+}
+
+public func <= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left <= right)
+}
+
+public func ~= <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: AttributeType) -> Predicate<T> {
+  return Predicate(predicate: left ~= right)
+}
+
+public func << <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: [AttributeType]) -> Predicate<T> {
+  return Predicate(predicate: left << right)
+}
+
+public func << <T: NSManagedObject, AttributeType>(left: Attribute<AttributeType>, right: Range<AttributeType>) -> Predicate<T> {
+  return Predicate(predicate: left << right)
+}
+
+/// Returns an and predicate from the given predicates
+public func && <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: left.predicate && right.predicate)
+}
+
+/// Returns an or predicate from the given predicates
+public func || <T>(left: Predicate<T>, right: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: left.predicate || right.predicate)
+}
+
+/// Returns a predicate reversing the given predicate
+prefix public func ! <T>(predicate: Predicate<T>) -> Predicate<T> {
+  return Predicate(predicate: !predicate.predicate)
+}

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -69,6 +69,18 @@ extension QuerySet {
     return QuerySet(queryset:self, sortDescriptors:sortDescriptors.map(reverseSortDescriptor), predicate:predicate, range:range)
   }
 
+  // MARK: Type-safe Sorting
+
+  ///  Returns a new QuerySet containing objects ordered by the given sort descriptor.
+  public func orderBy(closure:((ModelType.Type) -> (SortDescriptor<ModelType>))) -> QuerySet<ModelType> {
+    return orderBy(closure(ModelType.self).sortDescriptor)
+  }
+
+  /// Returns a new QuerySet containing objects ordered by the given sort descriptors.
+  public func orderBy(closure:((ModelType.Type) -> ([SortDescriptor<ModelType>]))) -> QuerySet<ModelType> {
+    return orderBy(closure(ModelType.self).map { $0.sortDescriptor })
+  }
+
   // MARK: Filtering
 
   /// Returns a new QuerySet containing objects that match the given predicate.

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -99,6 +99,28 @@ extension QuerySet {
     let excludePredicate = NSCompoundPredicate(type: NSCompoundPredicateType.AndPredicateType, subpredicates: predicates)
     return exclude(excludePredicate)
   }
+
+  // MARK: Type-safe filtering
+
+  /// Returns a new QuerySet containing objects that match the given predicate.
+  public func filter(closure:((ModelType.Type) -> (Predicate<ModelType>))) -> QuerySet<ModelType> {
+    return filter(closure(ModelType.self).predicate)
+  }
+
+  /// Returns a new QuerySet containing objects that exclude the given predicate.
+  public func exclude(closure:((ModelType.Type) -> (Predicate<ModelType>))) -> QuerySet<ModelType> {
+    return exclude(closure(ModelType.self).predicate)
+  }
+
+  /// Returns a new QuerySet containing objects that match the given predicatess.
+  public func filter(closures:[((ModelType.Type) -> (Predicate<ModelType>))]) -> QuerySet<ModelType> {
+    return filter(closures.map { $0(ModelType.self).predicate })
+  }
+
+  /// Returns a new QuerySet containing objects that exclude the given predicates.
+  public func exclude(closures:[((ModelType.Type) -> (Predicate<ModelType>))]) -> QuerySet<ModelType> {
+    return exclude(closures.map { $0(ModelType.self).predicate })
+  }
 }
 
 /// Functions for evauluating a QuerySet

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 /// Represents a lazy database lookup for a set of objects.
-public class QuerySet<ModelType : NSManagedObject> : Equatable, SequenceType {
+public class QuerySet<ModelType : NSManagedObject> : Equatable {
   /// Returns the managed object context that will be used to execute any requests.
   public let context:NSManagedObjectContext
 
@@ -230,17 +230,6 @@ extension QuerySet {
     }
 
     return deletedCount
-  }
-
-  // MARK: Sequence
-
-  public func generate() -> IndexingGenerator<Array<ModelType>> {
-    do {
-      let generator = try self.array().generate()
-      return generator
-    } catch {
-      return [].generate()
-    }
   }
 }
 

--- a/QueryKit/QuerySet.swift
+++ b/QueryKit/QuerySet.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 /// Represents a lazy database lookup for a set of objects.
-public class QuerySet<ModelType : NSManagedObject> : SequenceType, Equatable {
+public class QuerySet<ModelType : NSManagedObject> : Equatable, SequenceType {
   /// Returns the managed object context that will be used to execute any requests.
   public let context:NSManagedObjectContext
 

--- a/QueryKit/SortDescriptor.swift
+++ b/QueryKit/SortDescriptor.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Represents a sort descriptor for a specific model
+public struct SortDescriptor<ModelType : NSManagedObject> {
+  let sortDescriptor:NSSortDescriptor
+
+  init(sortDescriptor:NSSortDescriptor) {
+    self.sortDescriptor = sortDescriptor
+  }
+}
+
+extension Attribute {
+  /// Returns an ascending sort descriptor for the attribute
+  public func ascending<T : NSManagedObject>() -> SortDescriptor<T> {
+    return SortDescriptor(sortDescriptor: ascending())
+  }
+
+  /// Returns a descending sort descriptor for the attribute
+  public func descending<T : NSManagedObject>() -> SortDescriptor<T> {
+    return SortDescriptor(sortDescriptor: descending())
+  }
+}

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -17,8 +17,8 @@ class AttributeTests: XCTestCase {
     attribute = Attribute("age")
   }
 
-  func testAttributeHasName() {
-    XCTAssertEqual(attribute.name, "age")
+  func testAttributeHasKey() {
+    XCTAssertEqual(attribute.key, "age")
   }
 
   func testAttributeExpression() {
@@ -32,7 +32,7 @@ class AttributeTests: XCTestCase {
   func testCompoundAttributeCreation() {
     let personCompanyNameAttribute = Attribute<NSString>(attributes:["company", "name"])
 
-    XCTAssertEqual(personCompanyNameAttribute.name, "company.name")
+    XCTAssertEqual(personCompanyNameAttribute.key, "company.name")
     XCTAssertEqual(personCompanyNameAttribute.expression.keyPath, "company.name")
   }
 

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -14,7 +14,6 @@ class AttributeTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-
     attribute = Attribute("age")
   }
 

--- a/QueryKitTests/PredicateTests.swift
+++ b/QueryKitTests/PredicateTests.swift
@@ -86,14 +86,8 @@ class PredicateTests: XCTestCase {
     XCTAssertEqual(predicate.predicate, NSPredicate(format:"age BETWEEN %@", [5, 10]))
   }
 
-  func testOptionalEqualityOperator() {
-    let attribute = Attribute<String?>("name")
-    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
-    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
-  }
-
-  func testOptionalNSObjectEqualityOperator() {
-    let attribute = Attribute<NSString?>("name")
+  func testNSObjectEqualityOperator() {
+    let attribute = Attribute<NSString>("name")
     let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
     XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
   }

--- a/QueryKitTests/PredicateTests.swift
+++ b/QueryKitTests/PredicateTests.swift
@@ -7,24 +7,114 @@
 //
 
 import XCTest
-import QueryKit
+@testable import QueryKit
+
+
+class NSPredicateTests: XCTestCase {
+  var namePredicate = NSPredicate(format: "name == Kyle")
+  var agePredicate = NSPredicate(format: "age >= 21")
+
+  func testAndPredicate() {
+    let predicate = namePredicate && agePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
+  }
+
+  func testOrPredicate() {
+    let predicate = namePredicate || agePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
+  }
+
+  func testNotPredicate() {
+    let predicate = !namePredicate
+    XCTAssertEqual(predicate, NSPredicate(format: "NOT name == Kyle"))
+  }
+}
+
 
 class PredicateTests: XCTestCase {
-    var namePredicate = NSPredicate(format: "name == Kyle")
-    var agePredicate = NSPredicate(format: "age >= 21")
+  var attribute:Attribute<Int>!
 
-    func testAndPredicate() {
-        let predicate = namePredicate && agePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
-    }
+  override func setUp() {
+    super.setUp()
+    attribute = Attribute("age")
+  }
 
-    func testOrPredicate() {
-        let predicate = namePredicate || agePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
-    }
+  // MARK: Operators
 
-    func testNotPredicate() {
-        let predicate = !namePredicate
-        XCTAssertEqual(predicate, NSPredicate(format: "NOT name == Kyle"))
-    }
+  func testEqualityOperator() {
+    let predicate:Predicate<NSManagedObject> = attribute == 10
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age == 10"))
+  }
+
+  func testInequalityOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute != 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age != 10"))
+  }
+
+  func testGreaterThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute > 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age > 10"))
+  }
+
+  func testGreaterOrEqualThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute >= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age >= 10"))
+  }
+
+  func testLessThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute < 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age < 10"))
+  }
+
+  func testLessOrEqualThanOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute <= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age <= 10"))
+  }
+
+  func testLikeOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute ~= 10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age LIKE 10"))
+  }
+
+  func testInOperator() {
+    let predicate:Predicate<NSManagedObject> = (attribute << [5, 10])
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age IN %@", [5, 10]))
+  }
+
+  func testBetweenRangeOperator() {
+    let predicate:Predicate<NSManagedObject> = attribute << (5..<10)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age BETWEEN %@", [5, 10]))
+  }
+
+  func testOptionalEqualityOperator() {
+    let attribute = Attribute<String?>("name")
+    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  func testOptionalNSObjectEqualityOperator() {
+    let attribute = Attribute<NSString?>("name")
+    let predicate:Predicate<NSManagedObject> = (attribute == "kyle")
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  // MARK:
+
+  var namePredicate = Predicate<NSManagedObject>(predicate: NSPredicate(format: "name == Kyle"))
+  var agePredicate = Predicate<NSManagedObject>(predicate: NSPredicate(format: "age >= 21"))
+
+  func testAndPredicate() {
+    let predicate = namePredicate && agePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "name == Kyle AND age >= 21"))
+  }
+
+  func testOrPredicate() {
+    let predicate = namePredicate || agePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "name == Kyle OR age >= 21"))
+  }
+
+  func testNotPredicate() {
+    let predicate = !namePredicate
+    XCTAssertEqual(predicate.predicate, NSPredicate(format: "NOT name == Kyle"))
+  }
 }

--- a/QueryKitTests/QueryKitTests.swift
+++ b/QueryKitTests/QueryKitTests.swift
@@ -12,6 +12,7 @@ import CoreData
 
 @objc(Person) class Person : NSManagedObject {
   @NSManaged var name:String
+  @NSManaged var company:Company?
 
   class var entityName:String {
     return "Person"
@@ -19,6 +20,32 @@ import CoreData
 
   class var name:Attribute<String> {
     return Attribute("name")
+  }
+
+  class var company:Attribute<Company> {
+    return Attribute("company")
+  }
+}
+
+@objc(Company) class Company : NSManagedObject {
+  @NSManaged var name:String
+
+  class var entityName:String {
+    return "Company"
+  }
+
+  class var name:Attribute<String> {
+    return Attribute("name")
+  }
+
+  class func create(context:NSManagedObjectContext) -> Company {
+    return NSEntityDescription.insertNewObjectForEntityForName(Company.entityName, inManagedObjectContext: context) as! Company
+  }
+}
+
+extension Attribute where AttributeType: Company {
+  var name:Attribute<String> {
+    return attribute(AttributeType.name)
   }
 }
 
@@ -29,18 +56,43 @@ extension Person {
 }
 
 func managedObjectModel() -> NSManagedObjectModel {
+  let companyEntity = NSEntityDescription()
+  companyEntity.name = Company.entityName
+  companyEntity.managedObjectClassName = "Company"
+
   let personEntity = NSEntityDescription()
   personEntity.name = Person.entityName
   personEntity.managedObjectClassName = "Person"
+
+  let companyNameAttribute = NSAttributeDescription()
+  companyNameAttribute.name = "name"
+  companyNameAttribute.attributeType = NSAttributeType.StringAttributeType
+  companyNameAttribute.optional = false
+
+  let companyPeopleAttribute = NSRelationshipDescription()
+  companyPeopleAttribute.name = "members"
+  companyPeopleAttribute.maxCount = 0
+  companyPeopleAttribute.destinationEntity = personEntity
 
   let personNameAttribute = NSAttributeDescription()
   personNameAttribute.name = "name"
   personNameAttribute.attributeType = NSAttributeType.StringAttributeType
   personNameAttribute.optional = false
-  personEntity.properties = [personNameAttribute]
+
+  let personCompanyRelation = NSRelationshipDescription()
+  personCompanyRelation.name = "company"
+  personCompanyRelation.destinationEntity = companyEntity
+  personCompanyRelation.maxCount = 1
+  personCompanyRelation.optional = true
+
+  companyPeopleAttribute.inverseRelationship = personCompanyRelation
+  personCompanyRelation.inverseRelationship = companyPeopleAttribute
+
+  companyEntity.properties = [companyNameAttribute, companyPeopleAttribute]
+  personEntity.properties = [personNameAttribute, personCompanyRelation]
 
   let model = NSManagedObjectModel()
-  model.entities = [personEntity]
+  model.entities = [personEntity, companyEntity]
 
   return model
 }
@@ -50,7 +102,9 @@ func persistentStoreCoordinator() -> NSPersistentStoreCoordinator {
   let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
   do {
     try persistentStoreCoordinator.addPersistentStoreWithType(NSInMemoryStoreType, configuration: nil, URL: nil, options: nil)
-  } catch _ {
+  } catch {
+    print(error)
+    fatalError()
   }
   return persistentStoreCoordinator
 }

--- a/QueryKitTests/QueryKitTests.swift
+++ b/QueryKitTests/QueryKitTests.swift
@@ -16,6 +16,10 @@ import CoreData
   class var entityName:String {
     return "Person"
   }
+
+  class var name:Attribute<String> {
+    return Attribute("name")
+  }
 }
 
 extension Person {

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import CoreData
 import QueryKit
 
+
 class QuerySetTests: XCTestCase {
   var context:NSManagedObjectContext!
   var queryset:QuerySet<Person>!
@@ -80,6 +81,12 @@ class QuerySetTests: XCTestCase {
     XCTAssertEqual(qs.predicate!, NSPredicate(format: "isEmployed == YES"))
   }
 
+  func testTypeSafeFilter() {
+    let qs = queryset.filter { $0.name == "Kyle" }
+
+    XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
+  }
+
   // MARK: Exclusion
 
   func testExcludePredicate() {
@@ -99,6 +106,12 @@ class QuerySetTests: XCTestCase {
   func testExcludeBooleanAttribute() {
     let qs = queryset.exclude(Attribute<Bool>("isEmployed"))
     XCTAssertEqual(qs.predicate!, NSPredicate(format: "isEmployed == NO"))
+  }
+
+  func testTypeSafeExclude() {
+    let qs = queryset.exclude { $0.name == "Kyle" }
+
+    XCTAssertEqual(qs.predicate?.description, "NOT name == \"Kyle\"")
   }
 
   // Fetch Request

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -49,6 +49,17 @@ class QuerySetTests: XCTestCase {
     XCTAssertTrue(qs.sortDescriptors == [sortDescriptor])
   }
 
+  func testTypeSafeOrderBySortDescriptor() {
+    let qs = queryset.orderBy { $0.name.ascending() }
+    XCTAssertTrue(qs.sortDescriptors == [NSSortDescriptor(key: "name", ascending: true)])
+  }
+
+  func testTypeSafeOrderBySortDescriptors() {
+    let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+    let qs = queryset.orderBy { [$0.name.ascending()] }
+    XCTAssertTrue(qs.sortDescriptors == [sortDescriptor])
+  }
+
   func testReverseOrdering() {
     let nameSortDescriptor = NSSortDescriptor(key: "name", ascending: true)
     let ageSortDescriptor = NSSortDescriptor(key: "age", ascending: true)

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -100,7 +100,7 @@ class QuerySetTests: XCTestCase {
   }
 
   func testTypeSafeFilter() {
-    let qs:QuerySet<Person> = queryset.filter { $0.name == "Kyle" }
+    let qs = queryset.filter { $0.name == "Kyle" }
 
     XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
   }
@@ -248,18 +248,5 @@ class QuerySetTests: XCTestCase {
 
     XCTAssertEqual(deletedCount, 2)
     XCTAssertEqual(count, 3)
-  }
-
-  // MARK: Sequence
-
-  func testSequence() {
-    let qs = queryset.orderBy(NSSortDescriptor(key: "name", ascending: true))
-    var objects = [Person]()
-
-    for object in qs {
-      objects.append(object)
-    }
-
-    XCTAssertEqual(objects.count, 5)
   }
 }

--- a/QueryKitTests/QuerySetTests.swift
+++ b/QueryKitTests/QuerySetTests.swift
@@ -21,9 +21,16 @@ class QuerySetTests: XCTestCase {
     context = NSManagedObjectContext()
     context.persistentStoreCoordinator = persistentStoreCoordinator()
 
+    let company = Company.create(context)
+    company.name = "Cocode"
+
     for name in ["Kyle", "Orta", "Ayaka", "Mark", "Scott"] {
       let person = Person.create(context)
       person.name = name
+
+      if name == "Kyle" {
+        person.company == "Cocode"
+      }
     }
 
     try! context.save()
@@ -93,9 +100,17 @@ class QuerySetTests: XCTestCase {
   }
 
   func testTypeSafeFilter() {
-    let qs = queryset.filter { $0.name == "Kyle" }
+    let qs:QuerySet<Person> = queryset.filter { $0.name == "Kyle" }
 
     XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
+  }
+
+  func testTypeSafeRelatedFilterPredicate() {
+    let at = Attribute<Company>("company")
+    XCTAssertEqual(at.name.key, "company.name")
+    let qs = queryset.filter { $0.company.name == "Cocode" }
+
+    XCTAssertEqual(qs.predicate?.description, "company.name == \"Cocode\"")
   }
 
   // MARK: Exclusion

--- a/QueryKitTests/SortDescriptorTests.swift
+++ b/QueryKitTests/SortDescriptorTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import QueryKit
+
+class SortDescriptorTests: XCTestCase {
+  var attribute:Attribute<Int>!
+
+  override func setUp() {
+    super.setUp()
+    attribute = Attribute("age")
+  }
+
+  func testAscendingSortDescriptor() {
+    let sortDescriptor:SortDescriptor<NSManagedObject> = attribute.ascending()
+    XCTAssertEqual(sortDescriptor.sortDescriptor, NSSortDescriptor(key: "age", ascending: true))
+  }
+
+  func testDescendingSortDescriptor() {
+    let sortDescriptor:SortDescriptor<NSManagedObject> = attribute.descending()
+    XCTAssertEqual(sortDescriptor.sortDescriptor, NSSortDescriptor(key: "age", ascending: false))
+  }
+}

--- a/README.md
+++ b/README.md
@@ -91,18 +91,12 @@ queryset[0..5]
 
 ##### Multiple objects
 
-A QuerySet is utterable, and it executes the query when you iterate over it. For example:
+You can convert a QuerySet to an array using the `array()` function. For example:
 
 ```swift
-for person in queryset {
+for person in try! queryset.array() {
   println("Hello \(person.name).")
 }
-```
-
-You can also convert the QuerySet to an Array:
-
-```swift
-queryset.array()
 ```
 
 ##### First object


### PR DESCRIPTION
This pull request introduces the ability to do type-safe filtering and sorting, for example:

```swift
Person.queryset(context)
  .filter { $0.company.name == "Cocode" }
  .orderBy { $0.name }
```

Providing you create the attribute extensions:

```swift
extension Person {
  class var name:Attribute<String> { return Attribute("name") }
  class var company:Attribute<Company> { return Attribute("company") }
}

extension Company {
  class var name:Attribute<String> { return Attribute("name") }
}

extension Attribute where AttributeType: Company {
  var name:Attribute<String> { return attribute(AttributeType.name) }
}
```