### PR TITLE
Make Attribute no longer equatable

### DIFF
--- a/QueryKit/Attribute.swift
+++ b/QueryKit/Attribute.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An attribute, representing an attribute on a model
-public struct Attribute<AttributeType> : Equatable {
+public struct Attribute<AttributeType> {
   public let key:String
 
   public init(_ key:String) {
@@ -56,12 +56,6 @@ public struct Attribute<AttributeType> : Equatable {
   public func attribute<T>(attribute:Attribute<T>) -> Attribute<T> {
     return Attribute<T>(attributes: [key, attribute.key])
   }
-}
-
-
-/// Returns true if two attributes have the same name
-public func == <AttributeType>(lhs: Attribute<AttributeType>, rhs: Attribute<AttributeType>) -> Bool {
-  return lhs.key == rhs.key
 }
 
 public func == <AttributeType>(left: Attribute<AttributeType>, right: AttributeType?) -> NSPredicate {

--- a/QueryKitTests/AttributeTests.swift
+++ b/QueryKitTests/AttributeTests.swift
@@ -25,10 +25,6 @@ class AttributeTests: XCTestCase {
     XCTAssertEqual(attribute.expression.keyPath, "age")
   }
 
-  func testEqualAttributesAreEquatable() {
-    XCTAssertEqual(attribute, Attribute<Int>("age"))
-  }
-
   func testCompoundAttributeCreation() {
     let personCompanyNameAttribute = Attribute<NSString>(attributes:["company", "name"])
 
@@ -110,13 +106,13 @@ class CollectionAttributeTests: XCTestCase {
   func testCountOfSet() {
     let setAttribute = Attribute<NSSet>("names")
     let countAttribute = count(setAttribute)
-    XCTAssertEqual(countAttribute, Attribute<Int>("names.@count"))
+    XCTAssertEqual(countAttribute.key, "names.@count")
   }
 
   func testCountOfOrderedSet() {
     let setAttribute = Attribute<NSOrderedSet>("names")
     let countAttribute = count(setAttribute)
-    XCTAssertEqual(countAttribute, Attribute<Int>("names.@count"))
+    XCTAssertEqual(countAttribute.key, "names.@count")
   }
 }
 

--- a/QueryKitTests/ObjectiveC/QKAttributeTests.swift
+++ b/QueryKitTests/ObjectiveC/QKAttributeTests.swift
@@ -38,7 +38,7 @@ class QKAttributeTests: XCTestCase {
   }
 
   func testConvertingQKAttributeToAttribute() {
-    XCTAssertEqual(attribute.asAttribute(), Attribute<AnyObject>("age"))
+    XCTAssertEqual(attribute.asAttribute().key, "age")
   }
 
   // MARK: Ordering


### PR DESCRIPTION
This confuses type inference.

Closes #43