### PR TITLE
Support KeyPath operations (filtering/sorting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,18 @@
 ### Breaking
 
 * Drops support for Swift 3 and Swift 4. Swift 5 or newer must be used.
+
+### Enhancements
+
+* Added support for ordering by Swift KeyPath, for example:
+
+    ```swift
+    queryset.orderBy(\.createdAt, ascending: true)
+    ```
+
+* Added support for filtering and excluding by Swift KeyPath, for example:
+
+    ```swift
+    queryset.exclude(\.name == "Kyle")
+    queryset.filter(\.createdAt > Date())
+    ```

--- a/Sources/QueryKit/Attribute.swift
+++ b/Sources/QueryKit/Attribute.swift
@@ -112,11 +112,11 @@ prefix public func ! (left: Attribute<Bool>) -> NSPredicate {
 
 public extension QuerySet {
   func filter(_ attribute:Attribute<Bool>) -> QuerySet<ModelType> {
-    return filter(attribute == true)
+    return filter((attribute == true) as NSPredicate)
   }
 
   func exclude(_ attribute:Attribute<Bool>) -> QuerySet<ModelType> {
-    return filter(attribute == false)
+    return filter((attribute == false) as NSPredicate)
   }
 }
 

--- a/Sources/QueryKit/KeyPath.swift
+++ b/Sources/QueryKit/KeyPath.swift
@@ -1,0 +1,86 @@
+import CoreData
+
+// MARK: Predicate
+
+public func == <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs == rhs)
+}
+
+public func != <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs != rhs)
+}
+
+public func > <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs > rhs)
+}
+
+public func >= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs >= rhs)
+}
+
+public func < <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs < rhs)
+}
+
+public func <= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs <= rhs)
+}
+
+public func ~= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> Predicate<R> {
+  return Predicate(predicate: lhs ~= rhs)
+}
+
+public func << <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: [V]) -> Predicate<R> {
+  return Predicate(predicate: lhs << rhs)
+}
+
+public func << <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: Range<V>) -> Predicate<R> {
+  return Predicate(predicate: lhs << rhs)
+}
+
+// MARK: - NSPredicate
+
+public func == <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute == rhs
+}
+
+public func != <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute != rhs
+}
+
+public func > <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute > rhs
+}
+
+public func >= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute >= rhs
+}
+
+public func < <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute < rhs
+}
+
+public func <= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute <= rhs
+}
+
+public func ~= <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: V) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute ~= rhs
+}
+
+public func << <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: [V]) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute << rhs
+}
+
+public func << <R : NSManagedObject, V>(lhs: KeyPath<R, V>, rhs: Range<V>) -> NSPredicate {
+  let attribute = Attribute<V>((lhs as AnyKeyPath)._kvcKeyPathString!)
+  return attribute << rhs
+}

--- a/Sources/QueryKit/QuerySet.swift
+++ b/Sources/QueryKit/QuerySet.swift
@@ -81,6 +81,11 @@ extension QuerySet {
   // MARK: Filtering
 
   /// Returns a new QuerySet containing objects that match the given predicate.
+  public func filter(_ predicate: Predicate<ModelType>) -> QuerySet<ModelType> {
+    return filter(predicate.predicate)
+  }
+
+  /// Returns a new QuerySet containing objects that match the given predicate.
   public func filter(_ predicate:NSPredicate) -> QuerySet<ModelType> {
     var futurePredicate = predicate
 
@@ -95,6 +100,11 @@ extension QuerySet {
   public func filter(_ predicates:[NSPredicate]) -> QuerySet<ModelType> {
     let newPredicate = NSCompoundPredicate(type: NSCompoundPredicate.LogicalType.and, subpredicates: predicates)
     return filter(newPredicate)
+  }
+
+  /// Returns a new QuerySet containing objects that exclude the given predicate.
+  public func exclude(_ predicate: Predicate<ModelType>) -> QuerySet<ModelType> {
+    return exclude(predicate.predicate)
   }
 
   /// Returns a new QuerySet containing objects that exclude the given predicate.

--- a/Sources/QueryKit/QuerySet.swift
+++ b/Sources/QueryKit/QuerySet.swift
@@ -63,6 +63,11 @@ extension QuerySet {
 
   // MARK: Type-safe Sorting
 
+  ///  Returns a new QuerySet containing objects ordered by the given key path.
+  public func orderBy<T>(_ keyPath: KeyPath<ModelType, T>, ascending: Bool) -> QuerySet<ModelType> {
+    return orderBy(NSSortDescriptor(key: (keyPath as AnyKeyPath)._kvcKeyPathString!, ascending: ascending))
+  }
+
   ///  Returns a new QuerySet containing objects ordered by the given sort descriptor.
   public func orderBy(_ closure:((ModelType.Type) -> (SortDescriptor<ModelType>))) -> QuerySet<ModelType> {
     return orderBy(closure(ModelType.self).sortDescriptor)

--- a/Tests/QueryKitTests/KeyPathTests.swift
+++ b/Tests/QueryKitTests/KeyPathTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import QueryKit
+
+class KeyPathTests: XCTestCase {
+  func testEqualityOperator() {
+    let predicate: Predicate<User> = \User.name == "kyle"
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  func testEqualityOperatorWithOptional() {
+    let predicate: Predicate<User> = \User.name == nil
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name == %@", NSNull()))
+  }
+
+  func testInequalityOperator() {
+    let predicate: Predicate<User> = \User.name != "kyle"
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name != 'kyle'"))
+  }
+
+  func testInqqualityOperatorWithOptional() {
+    let predicate: Predicate<User> = \User.name != nil
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name != %@", NSNull()))
+  }
+
+  func testGreaterThanOperator() {
+    let predicate: Predicate<User> = \User.age > 17
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age > 17"))
+  }
+
+  func testGreaterThanOrEqualOperator() {
+    let predicate: Predicate<User> = \User.age >= 18
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age >= 18"))
+  }
+
+  func testLessThanOperator() {
+    let predicate: Predicate<User> = \User.age < 18
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age < 18"))
+  }
+
+  func testLessThanOrEqualOperator() {
+    let predicate: Predicate<User> = \User.age <= 17
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age <= 17"))
+  }
+
+  func testLikeOperator() {
+    let predicate: Predicate<User> = \User.name ~= "k*"
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"name LIKE 'k*'"))
+  }
+
+  func testInOperator() {
+    let predicate: Predicate<User> = \User.age << [5, 10]
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age IN %@", [5, 10]))
+  }
+
+  func testBetweenRangeOperator() {
+    let predicate: Predicate<User> = \User.age << (32 ..< 64)
+    XCTAssertEqual(predicate.predicate, NSPredicate(format:"age BETWEEN %@", [32, 64]))
+  }
+}
+
+class KeyPathNSPredicateTests: XCTestCase {
+  func testEqualityOperator() {
+    let predicate: NSPredicate = \User.name == "kyle"
+    XCTAssertEqual(predicate, NSPredicate(format:"name == 'kyle'"))
+  }
+
+  func testEqualityOperatorWithOptional() {
+    let predicate: NSPredicate = \User.name == nil
+    XCTAssertEqual(predicate, NSPredicate(format:"name == %@", NSNull()))
+  }
+
+  func testInequalityOperator() {
+    let predicate: NSPredicate = \User.name != "kyle"
+    XCTAssertEqual(predicate, NSPredicate(format:"name != 'kyle'"))
+  }
+
+  func testInqqualityOperatorWithOptional() {
+    let predicate: NSPredicate = \User.name != nil
+    XCTAssertEqual(predicate, NSPredicate(format:"name != %@", NSNull()))
+  }
+
+  func testGreaterThanOperator() {
+    let predicate: NSPredicate = \User.age > 17
+    XCTAssertEqual(predicate, NSPredicate(format:"age > 17"))
+  }
+
+  func testGreaterThanOrEqualOperator() {
+    let predicate: NSPredicate = \User.age >= 18
+    XCTAssertEqual(predicate, NSPredicate(format:"age >= 18"))
+  }
+
+  func testLessThanOperator() {
+    let predicate: NSPredicate = \User.age < 18
+    XCTAssertEqual(predicate, NSPredicate(format:"age < 18"))
+  }
+
+  func testLessThanOrEqualOperator() {
+    let predicate: NSPredicate = \User.age <= 17
+    XCTAssertEqual(predicate, NSPredicate(format:"age <= 17"))
+  }
+
+  func testLikeOperator() {
+    let predicate: NSPredicate = \User.name ~= "k*"
+    XCTAssertEqual(predicate, NSPredicate(format:"name LIKE 'k*'"))
+  }
+
+  func testInOperator() {
+    let predicate: NSPredicate = \User.age << [5, 10]
+    XCTAssertEqual(predicate, NSPredicate(format:"age IN %@", [5, 10]))
+  }
+
+  func testBetweenRangeOperator() {
+    let predicate: NSPredicate = \User.age << (32 ..< 64)
+    XCTAssertEqual(predicate, NSPredicate(format:"age BETWEEN %@", [32, 64]))
+  }
+}
+
+class User: NSManagedObject {
+  @objc var name: String?
+  @NSManaged var age: Int
+}

--- a/Tests/QueryKitTests/QuerySetTests.swift
+++ b/Tests/QueryKitTests/QuerySetTests.swift
@@ -96,6 +96,11 @@ class QuerySetTests: XCTestCase {
 
   // MARK: Filtering
 
+  func testFilterKeyPath() {
+    let qs = queryset.filter(\.name == "Kyle")
+    XCTAssertEqual(qs.predicate?.description, "name == \"Kyle\"")
+  }
+
   func testFilterPredicate() {
     let predicate = NSPredicate(format: "name == Kyle")
     let qs = queryset.filter(predicate)
@@ -135,6 +140,11 @@ class QuerySetTests: XCTestCase {
   }
 
   // MARK: Exclusion
+
+  func testExcludeKeyPath() {
+    let qs = queryset.exclude(\.name == "Kyle")
+    XCTAssertEqual(qs.predicate?.description, "NOT name == \"Kyle\"")
+  }
 
   func testExcludePredicate() {
     let predicate = NSPredicate(format: "name == Kyle")

--- a/Tests/QueryKitTests/QuerySetTests.swift
+++ b/Tests/QueryKitTests/QuerySetTests.swift
@@ -44,6 +44,22 @@ class QuerySetTests: XCTestCase {
 
   // MARK: Sorting
 
+  func testOrderByKeyPathAscending() {
+    let qs = queryset.orderBy(\.name, ascending: true)
+
+    XCTAssertEqual(qs.sortDescriptors, [
+      NSSortDescriptor(key: "name", ascending: true),
+    ])
+  }
+
+  func testOrderByKeyPathDecending() {
+    let qs = queryset.orderBy(\.name, ascending: false)
+
+    XCTAssertEqual(qs.sortDescriptors, [
+      NSSortDescriptor(key: "name", ascending: false),
+    ])
+  }
+
   func testOrderBySortDescriptor() {
     let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
     let qs = queryset.orderBy(sortDescriptor)


### PR DESCRIPTION
Support using Swift 5 [KeyPath](https://developer.apple.com/documentation/swift/keypath) for ordering and filtering.

```swift
queryset
  .orderBy(\.createdAt, ascending: true)
  .filter(\.age >= 18)
  .exclude(\.name == "Kyle")
```