### PR TITLE
add library product to `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
   name: "QueryKit",
   products: [
+    .library(name: "QueryKit", targets: ["QueryKit"]),
   ],
   targets: [
     .target(name: "QueryKit", dependencies: []),


### PR DESCRIPTION
Currently the `products` field in `Package.swift` is empty, thus preventing proper integration with spm. 